### PR TITLE
lib.target.selection and trade.find.free

### DIFF
--- a/aiscripts/lib.target.selection.xml
+++ b/aiscripts/lib.target.selection.xml
@@ -1,0 +1,58 @@
+<?xml version='1.0' encoding='utf-8'?>
+<diff>
+  <replace sel="/aiscript/attention[@min='unknown']/actions/do_all[@exact='$targets.count']/do_elseif[@value='$distance lt 5500m']">
+    <do_else>
+      <set_value name="$priority" exact="[$priority + (10.0 - ($distance - [this.assignedcontrolled.maxcombatrange.all,1m].max)f / [this.assignedcontrolled.maxcombatrange.all,1m].max),0.01].max"/>
+      <debug_text text="'evaluated distance. priority: %s, distance: %sm'.[$priority, $distance]" chance="$debugchance"/>
+    </do_else>
+  </replace>
+  <add sel="/aiscript/attention[@min='unknown']/actions/do_all[@exact='$targets.count']/do_if[@value='$priority gt $highest']" pos="before">
+    <do_if value="this.assignedcontrolled.isclass.ship">
+      <do_if value="this.assignedcontrolled.isclass.ship_xl">
+        <set_value name="$priority" exact="$priority * (if $targets.{$i}.isclass.[class.ship_l, class.ship_xl, class.station] then 2 else (if $targets.{$i}.isclass.[class.ship_xs, class.ship_s] then 0.5 else 1))"/>
+      </do_if>
+      <do_elseif value="this.assignedcontrolled.isclass.ship_l">
+        <set_value name="$priority" exact="$priority * (if $targets.{$i}.isclass.[class.ship_m, class.ship_l, class.ship_xl] then 2 else (if $targets.{$i}.isclass.[class.ship_xs, class.ship_s] then 0.5 else 1))"/>
+      </do_elseif>
+      <do_elseif value="this.assignedcontrolled.isclass.ship_m">
+        <do_if value="(this.assignedcontrolled.ammostorage.missile.count) and (this.assignedcontrolled.dps.missiles.all gt 0)">
+          <do_for_each name="$missilelauncher" in="this.assignedcontrolled.weapons.operational.list">
+            <do_if value="(macro.weapon_gen_m_torpedo_01_mk1_macro == $missilelauncher.macro) or (macro.weapon_gen_m_torpedo_01_mk2_macro == $missilelauncher.macro)">
+              <set_value name="$hastorpedo" exact="$true"/>
+              <break/>
+            </do_if>
+            <do_if value="$hastorpedo">
+              <set_value name="$priority" exact="$priority * (if $targets.{$i}.isclass.[class.ship_l, class.ship_xl, class.station] then 2 else (if $targets.{$i}.isclass.[class.ship_xs, class.ship_s] then 0.5 else 1))"/>
+              <remove_value name="$hastorpedo"/>
+            </do_if>
+            <do_else>
+              <set_value name="$priority" exact="$priority * (if $targets.{$i}.isclass.[class.ship_s, class.ship_m, class.ship_l] then 2 else (if $targets.{$i}.isclass.[class.ship_xs, class.ship_xl, class.station] then 0.5 else 1))"/>
+            </do_else>
+          </do_for_each>
+        </do_if>
+        <do_else>
+          <set_value name="$priority" exact="$priority * (if $targets.{$i}.isclass.[class.ship_s, class.ship_m, class.ship_l] then 2 else (if $targets.{$i}.isclass.[class.ship_xs, class.ship_xl, class.station] then 0.5 else 1))"/>
+        </do_else>
+      </do_elseif>
+      <do_elseif value="this.assignedcontrolled.isclass.ship_s">
+        <do_if value="(this.assignedcontrolled.ammostorage.missile.count) and (this.assignedcontrolled.dps.missiles.all gt 0)">
+          <do_for_each name="$missilelauncher" in="this.assignedcontrolled.weapons.operational.list">
+            <do_if value="(macro.weapon_gen_s_torpedo_01_mk1_macro == $missilelauncher.macro) or (macro.weapon_gen_s_torpedo_01_mk2_macro == $missilelauncher.macro)">
+              <set_value name="$hastorpedo" exact="$true"/>
+              <break/>
+            </do_if>
+            <do_if value="$hastorpedo">
+              <set_value name="$priority" exact="$priority * (if $targets.{$i}.isclass.[class.ship_l, class.ship_xl, class.station] then 2 else (if $targets.{$i}.isclass.[class.ship_xs, class.ship_s] then 0.5 else 1))"/>
+            </do_if>
+            <do_else>
+              <set_value name="$priority" exact="$priority * (if $targets.{$i}.isclass.[class.ship_xs, class.ship_s, class.ship_m] then 2 else (if $targets.{$i}.isclass.[class.ship_l, class.ship_xl, class.station] then 0.5 else 1))"/>
+            </do_else>
+          </do_for_each>
+        </do_if>
+        <do_else>
+          <set_value name="$priority" exact="$priority * (if $targets.{$i}.isclass.[class.ship_xs, class.ship_s, class.ship_m] then 2 else (if $targets.{$i}.isclass.[class.ship_l, class.ship_xl, class.station] then 0.5 else 1))"/>
+        </do_else>
+      </do_elseif>
+    </do_if>
+  </add>
+</diff>

--- a/aiscripts/trade.find.free.xml
+++ b/aiscripts/trade.find.free.xml
@@ -1,11 +1,9 @@
 <?xml version='1.0' encoding='utf-8'?>
 <diff>
-  <add sel="/aiscript/attention[@min='unknown']/actions/do_all[@exact='$sellspaces.count']/do_if[@value='$buyoffers.count']/do_elseif[@value='$bestbuyoffers.keys.count gt 0 and this.ship.cargo.count gt 0']/do_if[@value='$tempbuyoffers.count']/comment()[3]" pos="before">
+  <replace sel="/aiscript/attention[@min='unknown']/actions/do_all[@exact='$sellspaces.count']/do_if[@value='$buyoffers.count']/do_elseif[@value='$bestbuyoffers.keys.count gt 0 and this.ship.cargo.count gt 0']/do_if[@value='$tempbuyoffers.count']/set_value[@name='$randomindex'][@min='1'][@max='$sorted_offers.count']">
     <sort_trades tradelist="$tempbuyoffers" name="$sorted_offers" sorter="relativeprice"/>
+  </replace>
+  <add sel="/aiscript/attention[@min='unknown']/actions/do_all[@exact='$sellspaces.count']/do_if[@value='$buyoffers.count']/do_elseif[@value='$bestbuyoffers.keys.count gt 0 and this.ship.cargo.count gt 0']/do_if[@value='$tempbuyoffers.count']/set_value[@name='$buyoffer'][@exact='$sorted_offers.{$randomindex}']" pos="before">
+    <set_value name="$randomindex" exact="$sorted_offers.count" comment="no longer random, take the best trade"/>
   </add>
-  <remove sel="/aiscript/attention[@min='unknown']/actions/do_all[@exact='$sellspaces.count']/do_if[@value='$buyoffers.count']/do_elseif[@value='$bestbuyoffers.keys.count gt 0 and this.ship.cargo.count gt 0']/do_if[@value='$tempbuyoffers.count']/set_value[@name='$randomindex'][@min='1'][@max='$sorted_offers.count']/@min"/>
-  <remove sel="/aiscript/attention[@min='unknown']/actions/do_all[@exact='$sellspaces.count']/do_if[@value='$buyoffers.count']/do_elseif[@value='$bestbuyoffers.keys.count gt 0 and this.ship.cargo.count gt 0']/do_if[@value='$tempbuyoffers.count']/set_value[@name='$randomindex'][@max='$sorted_offers.count']/@max"/>
-  <remove sel="/aiscript/attention[@min='unknown']/actions/do_all[@exact='$sellspaces.count']/do_if[@value='$buyoffers.count']/do_elseif[@value='$bestbuyoffers.keys.count gt 0 and this.ship.cargo.count gt 0']/do_if[@value='$tempbuyoffers.count']/set_value[@name='$randomindex']/@profile"/>
-  <add sel="/aiscript/attention[@min='unknown']/actions/do_all[@exact='$sellspaces.count']/do_if[@value='$buyoffers.count']/do_elseif[@value='$bestbuyoffers.keys.count gt 0 and this.ship.cargo.count gt 0']/do_if[@value='$tempbuyoffers.count']/set_value[@name='$randomindex']" type="@exact">$sorted_offers.count</add>
-  <add sel="/aiscript/attention[@min='unknown']/actions/do_all[@exact='$sellspaces.count']/do_if[@value='$buyoffers.count']/do_elseif[@value='$bestbuyoffers.keys.count gt 0 and this.ship.cargo.count gt 0']/do_if[@value='$tempbuyoffers.count']/set_value[@name='$randomindex'][@exact='$sorted_offers.count']" type="@comment">no longer random, take the best trade</add>
 </diff>


### PR DESCRIPTION
lib.target.selection
Added functionality for ships to prefer similar sized targets.
XL prefer L/XL/Stations 2x, half-interested in XS/S
L prefer M/L/XL 2x, half-interested in XS/S
M prefer S/M/L 2x, half-interested in XS/XL/Stations
S prefer XS/S/M 2x, Half-interested in L/XL/Stations
S/M with Torp prefer L/XL/Stations 2x, half-interested in XS/S
Targets not covered by notes above stay at vanilla preference

trade.find.free
Cleaned up diff for making autotraders take best deal instead of a random positive trade.