### PR TITLE
Da name fixes

### DIFF
--- a/aiscripts/kuertee_aait_interrupts.xml
+++ b/aiscripts/kuertee_aait_interrupts.xml
@@ -2305,9 +2305,9 @@
 					<remove_value name="global.$kAAITByShipId.{'$' + @this.assignedcontrolled.idcode}.$attackData.$orderLocation_pos" />
 				</do_if>
 				<do_if value="@this.assignedcontrolled.isoperational">
-					<do_if value="$kAAIT_original_name? and @$kAAIT_original_name and (this.assignedcontrolled.knownname != @$kAAIT_original_name)">
-					<!-- Check exists, check not null, check if knownname != original. Removed chance from debug message so any ships that unintentionally got a name change can be tracked -->
-						<debug_text text="@this.assignedcontrolled.idcode + ' set_object_name reset'" />
+					<do_if value="$kAAIT_original_name? and @$kAAIT_original_name and (this.assignedcontrolled.knownname != @$kAAIT_original_name) and (not @this.assignedcontrolled.coverowner)">
+						<!-- Check exists, check not null, check if knownname != original. Removed chance from debug message so any ships that unintentionally got a name change can be tracked -->
+						<debug_text text="'MOD: KUDA -- %s(%s) -- set_object_name reset to %s.'.[@this.assignedcontrolled.knownname,@this.assignedcontrolled.idcode,$kAAIT_original_name]" />
 						<set_object_name object="this.assignedcontrolled" name="$kAAIT_original_name" />
 					</do_if>
 				</do_if>

--- a/aiscripts/kuertee_aait_interrupts.xml
+++ b/aiscripts/kuertee_aait_interrupts.xml
@@ -200,8 +200,8 @@
 							)
 						)
 					" comment="update only kaait-affected orders"> -->
-					<do_if value='not $kAAIT_original_name?'>
-						<set_value name="$kAAIT_original_name" exact="this.assignedcontrolled.name" />
+					<do_if value="not $kAAIT_original_name?">
+						<set_value name="$kAAIT_original_name" exact="this.assignedcontrolled.knownname" />
 					</do_if>
 					<do_if value="@global.$kAAIT.exists and global.$kAAIT.version != @$kAAIT_version"
 						comment="but orders that have kaait features acquire the code changes even if they are not used, so update ALL running orders">
@@ -2290,8 +2290,8 @@
 			<actions name="kAAIT_InitAttackScript" comment="only works in the fight.attack.object.* and move.attack.object.capital scripts">
 				<set_value name="$kAAIT_version" exact="global.$kAAIT.version" />
 				<set_value name="$kAAIT_defensibleTarget" exact="if $target.defensible then $target.defensible else $target" />
-				<do_if value='not $kAAIT_original_name?'>
-					<set_value name="$kAAIT_original_name" exact="this.assignedcontrolled.name" />
+				<do_if value="not $kAAIT_original_name?">
+					<set_value name="$kAAIT_original_name" exact="this.assignedcontrolled.knownname" />
 				</do_if>
 				<do_if value="@$kAAITParam_isAvoidHighRisk or @$kAAITParam_isStepForwardWithdraw">
 					<include_interrupt_actions ref="kAAIT_Init" />
@@ -2305,8 +2305,9 @@
 					<remove_value name="global.$kAAITByShipId.{'$' + @this.assignedcontrolled.idcode}.$attackData.$orderLocation_pos" />
 				</do_if>
 				<do_if value="@this.assignedcontrolled.isoperational">
-					<do_if value="@$kAAIT_original_name">
-						<debug_text text="@this.assignedcontrolled.idcode + ' set_object_name reset'" chance="if @this.assignedcontrolled.idcode == @global.$kAAIT.$debugChance_idCode or @global.$kAAIT.$debugChance_idCode == 'all' then @global.$kAAIT_Data.$debugChance else 0" />
+					<do_if value="$kAAIT_original_name? and @$kAAIT_original_name and (this.assignedcontrolled.knownname != @$kAAIT_original_name)">
+					<!-- Check exists, check not null, check if knownname != original. Removed chance from debug message so any ships that unintentionally got a name change can be tracked -->
+						<debug_text text="@this.assignedcontrolled.idcode + ' set_object_name reset'" />
 						<set_object_name object="this.assignedcontrolled" name="$kAAIT_original_name" />
 					</do_if>
 				</do_if>

--- a/aiscripts/move.attack.object.capital.xml
+++ b/aiscripts/move.attack.object.capital.xml
@@ -267,8 +267,8 @@
 -->
 	<add pos="after" sel="//label[@name=&quot;fight&quot;]">
 		<do_if value="@this.assignedcontrolled.isoperational">
-			<do_if value="@$kAAIT_original_name">
-				<debug_text text="@this.assignedcontrolled.idcode + ' set_object_name reset'" chance="if @this.assignedcontrolled.idcode == @global.$kAAIT.$debugChance_idCode or @global.$kAAIT.$debugChance_idCode == 'all' then @global.$kAAIT_Data.$debugChance else 0" />
+			<do_if value="$kAAIT_original_name? and @$kAAIT_original_name and (this.assignedcontrolled.knownname != @$kAAIT_original_name) and (not @this.assignedcontrolled.coverowner)">
+				<debug_text text="'MOD: KUDA -- %s(%s) -- set_object_name reset to %s.'.[@this.assignedcontrolled.knownname,@this.assignedcontrolled.idcode,$kAAIT_original_name]" />
 				<set_object_name object="this.assignedcontrolled" name="$kAAIT_original_name" />
 			</do_if>
 		</do_if>
@@ -442,8 +442,8 @@
 	<add pos="after" sel="//attention[@min=&quot;unknown&quot;]">
 		<on_abort>
 			<do_if value="@this.assignedcontrolled.isoperational">
-				<do_if value="@$kAAIT_original_name">
-					<debug_text text="@this.assignedcontrolled.idcode + ' set_object_name reset'" chance="if @this.assignedcontrolled.idcode == @global.$kAAIT.$debugChance_idCode or @global.$kAAIT.$debugChance_idCode == 'all' then @global.$kAAIT_Data.$debugChance else 0" />
+				<do_if value="$kAAIT_original_name? and @$kAAIT_original_name and (this.assignedcontrolled.knownname != @$kAAIT_original_name) and (not @this.assignedcontrolled.coverowner)">
+					<debug_text text="'MOD: KUDA -- %s(%s) -- set_object_name reset to %s.'.[@this.assignedcontrolled.knownname,@this.assignedcontrolled.idcode,$kAAIT_original_name]" />
 					<set_object_name object="this.assignedcontrolled" name="$kAAIT_original_name" />
 				</do_if>
 			</do_if>

--- a/aiscripts/move.generic.xml
+++ b/aiscripts/move.generic.xml
@@ -144,7 +144,7 @@
 	<add pos="before" sel="//label[@name=&quot;start&quot;]">
 		<label name="kAAIT_label_start" />
 		<set_value name="$kAAIT_version" exact="global.$kAAIT.version" />
-		<do_if value="(not this.assignedcontrolled.name) or this.assignedcontrolled.name == ''" comment="fix bug that removed names">
+		<do_if value="(not this.assignedcontrolled.knownname) or this.assignedcontrolled.knownname == ''" comment="fix bug that removed names">
 			<set_object_name object="this.assignedcontrolled" name="this.assignedcontrolled.macro.name" />
 		</do_if>
 

--- a/aiscripts/move.kuertee.avoid.xml
+++ b/aiscripts/move.kuertee.avoid.xml
@@ -77,7 +77,7 @@
 			<label name="start"/>
 			<debug_text text="@this.assignedcontrolled.idcode + ' LABEL start'" chance="if @this.assignedcontrolled.idcode == @global.$kAAIT.$debugChance_idCode or @global.$kAAIT.$debugChance_idCode == 'all' then @global.$kAAIT_Data.$debugChance else 0" />
 			<do_if value="not $kAAIT_original_name?">
-				<set_value name="$kAAIT_original_name" exact="this.assignedcontrolled.name" />
+				<set_value name="$kAAIT_original_name" exact="this.assignedcontrolled.knownname" />
 			</do_if>
 			<do_if value="$target.defensible">
 				<set_value name="$defensibleTarget" exact="$target.defensible" />
@@ -413,8 +413,9 @@
 			<stop_moving object="this.assignedcontrolled" />
 			<!-- <reset_flight_behaviour object="this.assignedcontrolled" /> -->
 			<do_if value="@this.assignedcontrolled.isoperational">
-				<do_if value="@$kAAIT_original_name">
-					<debug_text text="@this.assignedcontrolled.idcode + ' set_object_name reset'" chance="if @this.assignedcontrolled.idcode == @global.$kAAIT.$debugChance_idCode or @global.$kAAIT.$debugChance_idCode == 'all' then @global.$kAAIT_Data.$debugChance else 0" />
+				<do_if value="$kAAIT_original_name? and @$kAAIT_original_name and (this.assignedcontrolled.knownname != @$kAAIT_original_name)">
+					<!-- Check exists, check not null, check if knownname != original. Removed chance from debug message so any ships that unintentionally got a name change can be tracked -->
+					<debug_text text="@this.assignedcontrolled.idcode + ' set_object_name reset'" />
 					<set_object_name object="this.assignedcontrolled" name="$kAAIT_original_name" />
 				</do_if>
 			</do_if>
@@ -439,8 +440,9 @@
 	</attention>
 	<on_abort>
 		<do_if value="@this.assignedcontrolled.isoperational">
-			<do_if value="@$kAAIT_original_name">
-				<debug_text text="@this.assignedcontrolled.idcode + ' set_object_name reset'" chance="if @this.assignedcontrolled.idcode == @global.$kAAIT.$debugChance_idCode or @global.$kAAIT.$debugChance_idCode == 'all' then @global.$kAAIT_Data.$debugChance else 0" />
+			<do_if value="$kAAIT_original_name? and @$kAAIT_original_name and (this.assignedcontrolled.knownname != @$kAAIT_original_name)">
+					<!-- Check exists, check not null, check if knownname != original. Removed chance from debug message so any ships that unintentionally got a name change can be tracked -->
+				<debug_text text="@this.assignedcontrolled.idcode + ' set_object_name reset'" />
 				<set_object_name object="this.assignedcontrolled" name="$kAAIT_original_name" />
 			</do_if>
 		</do_if>

--- a/aiscripts/move.kuertee.avoid.xml
+++ b/aiscripts/move.kuertee.avoid.xml
@@ -413,9 +413,9 @@
 			<stop_moving object="this.assignedcontrolled" />
 			<!-- <reset_flight_behaviour object="this.assignedcontrolled" /> -->
 			<do_if value="@this.assignedcontrolled.isoperational">
-				<do_if value="$kAAIT_original_name? and @$kAAIT_original_name and (this.assignedcontrolled.knownname != @$kAAIT_original_name)">
+				<do_if value="$kAAIT_original_name? and @$kAAIT_original_name and (this.assignedcontrolled.knownname != @$kAAIT_original_name) and (not @this.assignedcontrolled.coverowner)">
 					<!-- Check exists, check not null, check if knownname != original. Removed chance from debug message so any ships that unintentionally got a name change can be tracked -->
-					<debug_text text="@this.assignedcontrolled.idcode + ' set_object_name reset'" />
+					<debug_text text="'MOD: KUDA -- %s(%s) -- set_object_name reset to %s.'.[@this.assignedcontrolled.knownname,@this.assignedcontrolled.idcode,$kAAIT_original_name]" />
 					<set_object_name object="this.assignedcontrolled" name="$kAAIT_original_name" />
 				</do_if>
 			</do_if>
@@ -440,9 +440,9 @@
 	</attention>
 	<on_abort>
 		<do_if value="@this.assignedcontrolled.isoperational">
-			<do_if value="$kAAIT_original_name? and @$kAAIT_original_name and (this.assignedcontrolled.knownname != @$kAAIT_original_name)">
-					<!-- Check exists, check not null, check if knownname != original. Removed chance from debug message so any ships that unintentionally got a name change can be tracked -->
-				<debug_text text="@this.assignedcontrolled.idcode + ' set_object_name reset'" />
+			<do_if value="$kAAIT_original_name? and @$kAAIT_original_name and (this.assignedcontrolled.knownname != @$kAAIT_original_name) and (not @this.assignedcontrolled.coverowner)">
+				<!-- Check exists, check not null, check if knownname != original. Removed chance from debug message so any ships that unintentionally got a name change can be tracked -->
+				<debug_text text="'MOD: KUDA -- %s(%s) -- set_object_name reset to %s.'.[@this.assignedcontrolled.knownname,@this.assignedcontrolled.idcode,$kAAIT_original_name]" />
 				<set_object_name object="this.assignedcontrolled" name="$kAAIT_original_name" />
 			</do_if>
 		</do_if>

--- a/aiscripts/move.kuertee.engage.position.xml
+++ b/aiscripts/move.kuertee.engage.position.xml
@@ -83,7 +83,7 @@
 			<label name="start" />
 			<debug_text text="@this.assignedcontrolled.idcode + ' LABEL start'" chance="if @this.assignedcontrolled.idcode == @global.$kAAIT.$debugChance_idCode or @global.$kAAIT.$debugChance_idCode == 'all' then @global.$kAAIT_Data.$debugChance else 0" />
 			<do_if value="not $kAAIT_original_name?">
-				<set_value name="$kAAIT_original_name" exact="this.assignedcontrolled.name" />
+				<set_value name="$kAAIT_original_name" exact="this.assignedcontrolled.knownname" />
 			</do_if>
 			<do_if value="$target.defensible">
 				<set_value name="$defensibleTarget" exact="$target.defensible" />
@@ -332,8 +332,9 @@
 			<stop_moving object="this.assignedcontrolled" />
 			<!-- <reset_flight_behaviour object="this.assignedcontrolled" /> -->
 			<do_if value="@this.assignedcontrolled.isoperational">
-				<do_if value="@$kAAIT_original_name">
-					<debug_text text="@this.assignedcontrolled.idcode + ' set_object_name reset'" chance="if @this.assignedcontrolled.idcode == @global.$kAAIT.$debugChance_idCode or @global.$kAAIT.$debugChance_idCode == 'all' then @global.$kAAIT_Data.$debugChance else 0" />
+				<do_if value="$kAAIT_original_name? and @$kAAIT_original_name and (this.assignedcontrolled.knownname != @$kAAIT_original_name)">
+					<!-- Check exists, check not null, check if knownname != original. Removed chance from debug message so any ships that unintentionally got a name change can be tracked -->
+					<debug_text text="@this.assignedcontrolled.idcode + ' set_object_name reset'" />
 					<set_object_name object="this.assignedcontrolled" name="$kAAIT_original_name" />
 				</do_if>
 			</do_if>
@@ -352,8 +353,9 @@
 	</attention>
 	<on_abort>
 		<do_if value="@this.assignedcontrolled.isoperational">
-			<do_if value="@$kAAIT_original_name">
-				<debug_text text="@this.assignedcontrolled.idcode + ' set_object_name reset'" chance="if @this.assignedcontrolled.idcode == @global.$kAAIT.$debugChance_idCode or @global.$kAAIT.$debugChance_idCode == 'all' then @global.$kAAIT_Data.$debugChance else 0" />
+			<do_if value="$kAAIT_original_name? and @$kAAIT_original_name and (this.assignedcontrolled.knownname != @$kAAIT_original_name)">
+				<!-- Check exists, check not null, check if knownname != original. Removed chance from debug message so any ships that unintentionally got a name change can be tracked -->
+				<debug_text text="@this.assignedcontrolled.idcode + ' set_object_name reset'" />
 				<set_object_name object="this.assignedcontrolled" name="$kAAIT_original_name" />
 			</do_if>
 		</do_if>

--- a/aiscripts/move.kuertee.engage.position.xml
+++ b/aiscripts/move.kuertee.engage.position.xml
@@ -332,9 +332,9 @@
 			<stop_moving object="this.assignedcontrolled" />
 			<!-- <reset_flight_behaviour object="this.assignedcontrolled" /> -->
 			<do_if value="@this.assignedcontrolled.isoperational">
-				<do_if value="$kAAIT_original_name? and @$kAAIT_original_name and (this.assignedcontrolled.knownname != @$kAAIT_original_name)">
+				<do_if value="$kAAIT_original_name? and @$kAAIT_original_name and (this.assignedcontrolled.knownname != @$kAAIT_original_name) and (not @this.assignedcontrolled.coverowner)">
 					<!-- Check exists, check not null, check if knownname != original. Removed chance from debug message so any ships that unintentionally got a name change can be tracked -->
-					<debug_text text="@this.assignedcontrolled.idcode + ' set_object_name reset'" />
+					<debug_text text="'MOD: KUDA -- %s(%s) -- set_object_name reset to %s.'.[@this.assignedcontrolled.knownname,@this.assignedcontrolled.idcode,$kAAIT_original_name]" />
 					<set_object_name object="this.assignedcontrolled" name="$kAAIT_original_name" />
 				</do_if>
 			</do_if>
@@ -353,9 +353,9 @@
 	</attention>
 	<on_abort>
 		<do_if value="@this.assignedcontrolled.isoperational">
-			<do_if value="$kAAIT_original_name? and @$kAAIT_original_name and (this.assignedcontrolled.knownname != @$kAAIT_original_name)">
+			<do_if value="$kAAIT_original_name? and @$kAAIT_original_name and (this.assignedcontrolled.knownname != @$kAAIT_original_name) and (not @this.assignedcontrolled.coverowner)">
 				<!-- Check exists, check not null, check if knownname != original. Removed chance from debug message so any ships that unintentionally got a name change can be tracked -->
-				<debug_text text="@this.assignedcontrolled.idcode + ' set_object_name reset'" />
+				<debug_text text="'MOD: KUDA -- %s(%s) -- set_object_name reset to %s.'.[@this.assignedcontrolled.knownname,@this.assignedcontrolled.idcode,$kAAIT_original_name]" />
 				<set_object_name object="this.assignedcontrolled" name="$kAAIT_original_name" />
 			</do_if>
 		</do_if>

--- a/aiscripts/move.kuertee.step.forward.xml
+++ b/aiscripts/move.kuertee.step.forward.xml
@@ -154,9 +154,9 @@
 
 			<label name="finish" />
 			<do_if value="@this.assignedcontrolled.isoperational">
-				<do_if value="$kAAIT_original_name? and @$kAAIT_original_name and (this.assignedcontrolled.knownname != @$kAAIT_original_name)">
+				<do_if value="$kAAIT_original_name? and @$kAAIT_original_name and (this.assignedcontrolled.knownname != @$kAAIT_original_name) and (not @this.assignedcontrolled.coverowner)">
 					<!-- Check exists, check not null, check if knownname != original. Removed chance from debug message so any ships that unintentionally got a name change can be tracked -->
-					<debug_text text="@this.assignedcontrolled.idcode + ' set_object_name reset'" />
+					<debug_text text="'MOD: KUDA -- %s(%s) -- set_object_name reset to %s.'.[@this.assignedcontrolled.knownname,@this.assignedcontrolled.idcode,$kAAIT_original_name]" />
 					<set_object_name object="this.assignedcontrolled" name="$kAAIT_original_name" />
 				</do_if>
 			</do_if>
@@ -172,9 +172,9 @@
 	</attention>
 	<on_abort>
 		<do_if value="@this.assignedcontrolled.isoperational">
-			<do_if value="$kAAIT_original_name? and @$kAAIT_original_name and (this.assignedcontrolled.knownname != @$kAAIT_original_name)">
+			<do_if value="$kAAIT_original_name? and @$kAAIT_original_name and (this.assignedcontrolled.knownname != @$kAAIT_original_name) and (not @this.assignedcontrolled.coverowner)">
 				<!-- Check exists, check not null, check if knownname != original. Removed chance from debug message so any ships that unintentionally got a name change can be tracked -->
-				<debug_text text="@this.assignedcontrolled.idcode + ' set_object_name reset'" />
+				<debug_text text="'MOD: KUDA -- %s(%s) -- set_object_name reset to %s.'.[@this.assignedcontrolled.knownname,@this.assignedcontrolled.idcode,$kAAIT_original_name]" />
 				<set_object_name object="this.assignedcontrolled" name="$kAAIT_original_name" />
 			</do_if>
 		</do_if>

--- a/aiscripts/move.kuertee.step.forward.xml
+++ b/aiscripts/move.kuertee.step.forward.xml
@@ -66,7 +66,7 @@
 			<label name="start"/>
 			<debug_text text="@this.assignedcontrolled.idcode + ' LABEL start'" chance="if @this.assignedcontrolled.idcode == @global.$kAAIT.$debugChance_idCode or @global.$kAAIT.$debugChance_idCode == 'all' then @global.$kAAIT_Data.$debugChance else 0" />
 			<do_if value="not $kAAIT_original_name?">
-				<set_value name="$kAAIT_original_name" exact="this.assignedcontrolled.name" />
+				<set_value name="$kAAIT_original_name" exact="this.assignedcontrolled.knownname" />
 			</do_if>
 			<do_if value="$target.defensible">
 				<set_value name="$defensibleTarget" exact="$target.defensible" />
@@ -154,8 +154,9 @@
 
 			<label name="finish" />
 			<do_if value="@this.assignedcontrolled.isoperational">
-				<do_if value="@$kAAIT_original_name">
-					<debug_text text="@this.assignedcontrolled.idcode + ' set_object_name reset'" chance="if @this.assignedcontrolled.idcode == @global.$kAAIT.$debugChance_idCode or @global.$kAAIT.$debugChance_idCode == 'all' then @global.$kAAIT_Data.$debugChance else 0" />
+				<do_if value="$kAAIT_original_name? and @$kAAIT_original_name and (this.assignedcontrolled.knownname != @$kAAIT_original_name)">
+					<!-- Check exists, check not null, check if knownname != original. Removed chance from debug message so any ships that unintentionally got a name change can be tracked -->
+					<debug_text text="@this.assignedcontrolled.idcode + ' set_object_name reset'" />
 					<set_object_name object="this.assignedcontrolled" name="$kAAIT_original_name" />
 				</do_if>
 			</do_if>
@@ -171,8 +172,9 @@
 	</attention>
 	<on_abort>
 		<do_if value="@this.assignedcontrolled.isoperational">
-			<do_if value="@$kAAIT_original_name">
-				<debug_text text="@this.assignedcontrolled.idcode + ' set_object_name reset'" chance="if @this.assignedcontrolled.idcode == @global.$kAAIT.$debugChance_idCode or @global.$kAAIT.$debugChance_idCode == 'all' then @global.$kAAIT_Data.$debugChance else 0" />
+			<do_if value="$kAAIT_original_name? and @$kAAIT_original_name and (this.assignedcontrolled.knownname != @$kAAIT_original_name)">
+				<!-- Check exists, check not null, check if knownname != original. Removed chance from debug message so any ships that unintentionally got a name change can be tracked -->
+				<debug_text text="@this.assignedcontrolled.idcode + ' set_object_name reset'" />
 				<set_object_name object="this.assignedcontrolled" name="$kAAIT_original_name" />
 			</do_if>
 		</do_if>

--- a/aiscripts/move.kuertee.withdraw.xml
+++ b/aiscripts/move.kuertee.withdraw.xml
@@ -66,7 +66,7 @@
 			<label name="start"/>
 			<debug_text text="@this.assignedcontrolled.idcode + ' LABEL start'" chance="if @this.assignedcontrolled.idcode == @global.$kAAIT.$debugChance_idCode or @global.$kAAIT.$debugChance_idCode == 'all' then @global.$kAAIT_Data.$debugChance else 0" />
 			<do_if value="not $kAAIT_original_name?">
-				<set_value name="$kAAIT_original_name" exact="this.assignedcontrolled.name" />
+				<set_value name="$kAAIT_original_name" exact="this.assignedcontrolled.knownname" />
 			</do_if>
 			<do_if value="$target.defensible">
 				<set_value name="$defensibleTarget" exact="$target.defensible" />
@@ -295,8 +295,9 @@
 
 			<label name="finish" />
 			<do_if value="@this.assignedcontrolled.isoperational">
-				<do_if value="@$kAAIT_original_name">
-					<debug_text text="@this.assignedcontrolled.idcode + ' set_object_name reset'" chance="if @this.assignedcontrolled.idcode == @global.$kAAIT.$debugChance_idCode or @global.$kAAIT.$debugChance_idCode == 'all' then @global.$kAAIT_Data.$debugChance else 0" />
+				<do_if value="$kAAIT_original_name? and @$kAAIT_original_name and (this.assignedcontrolled.knownname != @$kAAIT_original_name)">
+					<!-- Check exists, check not null, check if knownname != original. Removed chance from debug message so any ships that unintentionally got a name change can be tracked -->
+					<debug_text text="@this.assignedcontrolled.idcode + ' set_object_name reset'" />
 					<set_object_name object="this.assignedcontrolled" name="$kAAIT_original_name" />
 				</do_if>
 			</do_if>
@@ -314,8 +315,9 @@
 	</attention>
 	<on_abort>
 		<do_if value="@this.assignedcontrolled.isoperational">
-			<do_if value="@$kAAIT_original_name">
-				<debug_text text="@this.assignedcontrolled.idcode + ' set_object_name reset'" chance="if @this.assignedcontrolled.idcode == @global.$kAAIT.$debugChance_idCode or @global.$kAAIT.$debugChance_idCode == 'all' then @global.$kAAIT_Data.$debugChance else 0" />
+			<do_if value="$kAAIT_original_name? and @$kAAIT_original_name and (this.assignedcontrolled.knownname != @$kAAIT_original_name)">
+				<!-- Check exists, check not null, check if knownname != original. Removed chance from debug message so any ships that unintentionally got a name change can be tracked -->
+				<debug_text text="@this.assignedcontrolled.idcode + ' set_object_name reset'" />
 				<set_object_name object="this.assignedcontrolled" name="$kAAIT_original_name" />
 			</do_if>
 		</do_if>

--- a/aiscripts/move.kuertee.withdraw.xml
+++ b/aiscripts/move.kuertee.withdraw.xml
@@ -295,9 +295,9 @@
 
 			<label name="finish" />
 			<do_if value="@this.assignedcontrolled.isoperational">
-				<do_if value="$kAAIT_original_name? and @$kAAIT_original_name and (this.assignedcontrolled.knownname != @$kAAIT_original_name)">
+				<do_if value="$kAAIT_original_name? and @$kAAIT_original_name and (this.assignedcontrolled.knownname != @$kAAIT_original_name) and (not @this.assignedcontrolled.coverowner)">
 					<!-- Check exists, check not null, check if knownname != original. Removed chance from debug message so any ships that unintentionally got a name change can be tracked -->
-					<debug_text text="@this.assignedcontrolled.idcode + ' set_object_name reset'" />
+					<debug_text text="'MOD: KUDA -- %s(%s) -- set_object_name reset to %s.'.[@this.assignedcontrolled.knownname,@this.assignedcontrolled.idcode,$kAAIT_original_name]" />
 					<set_object_name object="this.assignedcontrolled" name="$kAAIT_original_name" />
 				</do_if>
 			</do_if>
@@ -315,9 +315,9 @@
 	</attention>
 	<on_abort>
 		<do_if value="@this.assignedcontrolled.isoperational">
-			<do_if value="$kAAIT_original_name? and @$kAAIT_original_name and (this.assignedcontrolled.knownname != @$kAAIT_original_name)">
+			<do_if value="$kAAIT_original_name? and @$kAAIT_original_name and (this.assignedcontrolled.knownname != @$kAAIT_original_name) and (not @this.assignedcontrolled.coverowner)">
 				<!-- Check exists, check not null, check if knownname != original. Removed chance from debug message so any ships that unintentionally got a name change can be tracked -->
-				<debug_text text="@this.assignedcontrolled.idcode + ' set_object_name reset'" />
+				<debug_text text="'MOD: KUDA -- %s(%s) -- set_object_name reset to %s.'.[@this.assignedcontrolled.knownname,@this.assignedcontrolled.idcode,$kAAIT_original_name]" />
 				<set_object_name object="this.assignedcontrolled" name="$kAAIT_original_name" />
 			</do_if>
 		</do_if>

--- a/aiscripts/order.fight.attack.object.xml
+++ b/aiscripts/order.fight.attack.object.xml
@@ -181,7 +181,7 @@
 	<add pos="before" sel="//label[@name=&quot;start&quot;]">
 		<label name="kAAIT_label_start" />
 		<set_value name="$kAAIT_version" exact="global.$kAAIT.version" />
-		<do_if value="(not this.assignedcontrolled.name) or this.assignedcontrolled.name == ''" comment="fix bug that removed names">
+		<do_if value="(not this.assignedcontrolled.knownname) or this.assignedcontrolled.knownname == ''" comment="fix bug that removed names">
 			<set_object_name object="this.assignedcontrolled" name="this.assignedcontrolled.macro.name" />
 		</do_if>
 

--- a/aiscripts/order.fight.escort.xml
+++ b/aiscripts/order.fight.escort.xml
@@ -74,12 +74,13 @@
 		<resume label="start" comment="in case the new order fails, do this" />
 
 		<label name="kAAIT_label_escort_during_attacks" />
-		<substitute_text text="$kAAIT_testName" source="this.assignedcontrolled.name">
+		<!-- DA - this substitude_text is a little strange to me, not sure the purpose -->
+		<substitute_text text="$kAAIT_testName" source="this.assignedcontrolled.knownname">
 			<replace string="'kAAIT escort attack pos'" with="'EXISTS!'"/>
 		</substitute_text>
-		<do_if value="$kAAIT_testName == this.assignedcontrolled.name" comment="'kAAIT escort attack pos' doesn't exist in the name, add it">
+		<do_if value="$kAAIT_testName == this.assignedcontrolled.knownname" comment="'kAAIT escort attack pos' doesn't exist in the name, add it">
 			<do_if value="not $kAAIT_original_name_escort?">
-				<set_value name="$kAAIT_original_name_escort" exact="this.assignedcontrolled.name" />
+				<set_value name="$kAAIT_original_name_escort" exact="this.assignedcontrolled.knownname" />
 			</do_if>
 			<do_if value="@this.assignedcontrolled.isoperational and @global.$kAAIT_Data.$debugChance">
 				<debug_text text="@this.assignedcontrolled.idcode + ' set_object_name kAAIT'" chance="if @this.assignedcontrolled.idcode == @global.$kAAIT.$debugChance_idCode or @global.$kAAIT.$debugChance_idCode == 'all' then @global.$kAAIT_Data.$debugChance else 0" />
@@ -96,8 +97,9 @@
 			<param name="position" value="$kAAIT_orderLocation_pos" />
 		</run_script>
 		<do_if value="@this.assignedcontrolled.isoperational">
-			<do_if value="@$kAAIT_original_name_escort">
-				<debug_text text="@this.assignedcontrolled.idcode + ' set_object_name reset'" chance="if @this.assignedcontrolled.idcode == @global.$kAAIT.$debugChance_idCode or @global.$kAAIT.$debugChance_idCode == 'all' then @global.$kAAIT_Data.$debugChance else 0" />
+			<do_if value="$kAAIT_original_name_escort? and @$kAAIT_original_name_escort and (this.assignedcontrolled.knownname != @$kAAIT_original_name_escort)">
+				<!-- Check exists, check not null, check if knownname != original. Removed chance from debug message so any ships that unintentionally got a name change can be tracked -->
+				<debug_text text="@this.assignedcontrolled.idcode + ' set_object_name reset'" />
 				<set_object_name object="this.assignedcontrolled" name="$kAAIT_original_name_escort" />
 			</do_if>
 		</do_if>
@@ -202,7 +204,7 @@
 
 		<label name="kAAIT_label_escort_during_attacks" />
 		<do_if value="not $kAAIT_original_name_escort?">
-			<set_value name="$kAAIT_original_name_escort" exact="this.assignedcontrolled.name" />
+			<set_value name="$kAAIT_original_name_escort" exact="this.assignedcontrolled.knownname" />
 		</do_if>
 		<do_if value="@this.assignedcontrolled.isoperational and @global.$kAAIT_Data.$debugChance">
 			<debug_text text="@this.assignedcontrolled.idcode + ' set_object_name kAAIT'" chance="if @this.assignedcontrolled.idcode == @global.$kAAIT.$debugChance_idCode or @global.$kAAIT.$debugChance_idCode == 'all' then @global.$kAAIT_Data.$debugChance else 0" />
@@ -218,8 +220,9 @@
 			<param name="position" value="$kAAIT_orderLocation_pos" />
 		</run_script>
 		<do_if value="@this.assignedcontrolled.isoperational">
-			<do_if value="@$kAAIT_original_name_escort">
-				<debug_text text="@this.assignedcontrolled.idcode + ' set_object_name reset'" chance="if @this.assignedcontrolled.idcode == @global.$kAAIT.$debugChance_idCode or @global.$kAAIT.$debugChance_idCode == 'all' then @global.$kAAIT_Data.$debugChance else 0" />
+			<do_if value="$kAAIT_original_name_escort? and @$kAAIT_original_name_escort and (this.assignedcontrolled.knownname != @$kAAIT_original_name_escort)">
+				<!-- Check exists, check not null, check if knownname != original. Removed chance from debug message so any ships that unintentionally got a name change can be tracked -->
+				<debug_text text="@this.assignedcontrolled.idcode + ' set_object_name reset'" />
 				<set_object_name object="this.assignedcontrolled" name="$kAAIT_original_name_escort" />
 			</do_if>
 		</do_if>

--- a/aiscripts/order.fight.escort.xml
+++ b/aiscripts/order.fight.escort.xml
@@ -97,9 +97,9 @@
 			<param name="position" value="$kAAIT_orderLocation_pos" />
 		</run_script>
 		<do_if value="@this.assignedcontrolled.isoperational">
-			<do_if value="$kAAIT_original_name_escort? and @$kAAIT_original_name_escort and (this.assignedcontrolled.knownname != @$kAAIT_original_name_escort)">
+			<do_if value="$kAAIT_original_name_escort? and @$kAAIT_original_name_escort and (this.assignedcontrolled.knownname != @$kAAIT_original_name_escort) and (not @this.assignedcontrolled.coverowner)">
 				<!-- Check exists, check not null, check if knownname != original. Removed chance from debug message so any ships that unintentionally got a name change can be tracked -->
-				<debug_text text="@this.assignedcontrolled.idcode + ' set_object_name reset'" />
+				<debug_text text="'MOD: KUDA -- %s(%s) -- set_object_name reset to %s.'.[@this.assignedcontrolled.knownname,@this.assignedcontrolled.idcode,$kAAIT_original_name_escort]" />
 				<set_object_name object="this.assignedcontrolled" name="$kAAIT_original_name_escort" />
 			</do_if>
 		</do_if>
@@ -220,9 +220,9 @@
 			<param name="position" value="$kAAIT_orderLocation_pos" />
 		</run_script>
 		<do_if value="@this.assignedcontrolled.isoperational">
-			<do_if value="$kAAIT_original_name_escort? and @$kAAIT_original_name_escort and (this.assignedcontrolled.knownname != @$kAAIT_original_name_escort)">
+			<do_if value="$kAAIT_original_name_escort? and @$kAAIT_original_name_escort and (this.assignedcontrolled.knownname != @$kAAIT_original_name_escort) and (not @this.assignedcontrolled.coverowner)">
 				<!-- Check exists, check not null, check if knownname != original. Removed chance from debug message so any ships that unintentionally got a name change can be tracked -->
-				<debug_text text="@this.assignedcontrolled.idcode + ' set_object_name reset'" />
+				<debug_text text="'MOD: KUDA -- %s(%s) -- set_object_name reset to %s.'.[@this.assignedcontrolled.knownname,@this.assignedcontrolled.idcode,$kAAIT_original_name_escort]" />
 				<set_object_name object="this.assignedcontrolled" name="$kAAIT_original_name_escort" />
 			</do_if>
 		</do_if>


### PR DESCRIPTION
Check comments for each push for specifics.

Changed any set_value $original name to use knownname instead of name. This should prevent any future ships from having unknown ship.

Changed do_if when resetting to original name to check if $original name exists, isn't null, and current name != original name.

Fixed bug for ships using cover owner.